### PR TITLE
Ask linguist to ignore html files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+html/static/api/* linguist-generated
+html/templates/* linguist-generated
+


### PR DESCRIPTION
This allows github to report the correct programming language for yamz.